### PR TITLE
getAuthorizationUrl() can set language

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ if (!empty($_GET['error'])) {
 
     // If we don't have an authorization code then get one
     $authUrl = $provider->getAuthorizationUrl();
+    // If we want to set approve page language (default is 'en-us')
+    // $authUrl = $provider->getAuthorizationUrl(['language' => 'zh-tw']);
     $_SESSION['oauth2state'] = $provider->getState();
     header('Location: ' . $authUrl);
     exit;

--- a/src/Provider/Yahoo.php
+++ b/src/Provider/Yahoo.php
@@ -64,12 +64,9 @@ class Yahoo extends AbstractProvider
 
     protected function getAuthorizationParameters(array $options)
     {
-        $params = array_merge(
-            parent::getAuthorizationParameters($options),
-            array_filter([
-                'language'    => $this->language
-            ])
-        );
+        $params = parent::getAuthorizationParameters($options);
+
+        $params['language'] = isset($options['language']) ? $options['language'] : $this->language;
 
         return $params;
     }


### PR DESCRIPTION
Since Yahoo OAuth user approve page can not detected user language. 
This change allow client to specify language when get getAuthorizationUrl by 

``` PHP
$authUrl = $provider->getAuthorizationUrl(['language' => 'zh-tw']);
header('Location: ' . $authUrl);
```
