### PR TITLE
Fix exception on fetching image.

### DIFF
--- a/src/Provider/Yahoo.php
+++ b/src/Provider/Yahoo.php
@@ -102,26 +102,6 @@ class Yahoo extends AbstractProvider
     {
         $user = new YahooUser($response);
 
-        $imageUrl = $this->getUserImageUrl($response, $token);
-
-        return $user->setImageURL($imageUrl);
-    }
-
-    /**
-     * Get user image url from provider, if available
-     *
-     * @param  array $response
-     * @param  AccessToken $token
-     *
-     * @return string
-     */
-    protected function getUserImageUrl(array $response, AccessToken $token)
-    {
-        $image = $this->getUserImage($response, $token);
-
-        if (isset($image['image']['imageUrl'])) {
-            return $image['image']['imageUrl'];
-        }
-        return null;
+        return $user;
     }
 }


### PR DESCRIPTION
Attempting to fetch the image from Yahoo caused an exception in php 7.2 as the image url is provided with the profile and fetching the image returns a stream instead.